### PR TITLE
petites améliorations

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html itemscope itemtype="http://schema.org/Product">
+<html itemscope itemtype="http://schema.org/Product" xml:lang="fr" lang="fr">
 	<head>
 		<meta charset="utf-8" />
 		<title itemprop="name">Firefox OS</title>
@@ -11,17 +11,17 @@
 		<script src="http://www.mozfr.org/custom/js/jquery-1.7.2.min.js" type="text/javascript"></script>
 		<script src="//mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
 		<script src="http://www.mozfr.org/custom/js/nav-main.js" type="text/javascript"></script>
-		<meta name="description" content="Firefox OS vous offre toutes les fonctionnalités qui vous ont donné envie d'avoir un smartphone." />
+		<meta name="description" content="Firefox OS vous offre toutes les fonctionnalités qui vous ont donné envie d'avoir un smartphone" />
 		<meta name="twitter:card" content="summary" />
 		<meta name="twitter:site" content="@firefoxosfr" />
 		<meta name="twitter:creator" content="@mozilla_fr" />
 		<meta name="twitter:title" content="Firefox OS" />
-		<meta name="twitter:description" content="Firefox OS vous offre toutes les fonctionnalités qui vous ont donné envie d'avoir un smartphone." />
+		<meta name="twitter:description" content="Firefox OS vous offre toutes les fonctionnalités qui vous ont donné envie d'avoir un smartphone" />
 		<meta name="twitter:image:src" content="http://firefoxos.mozfr.org/img/zteopenc-redim.png" />
 		<meta property="og:title" content="Firefox OS" />
 		<meta property="og:url" content="http://firefoxos.mozfr.org/" />
 		<meta property="og:image" content="http://firefoxos.mozfr.org/img/zteopenc-redim.png" />
-		<meta property="og:description" content="Firefox OS vous offre toutes les fonctionnalités qui vous ont donné envie d'avoir un smartphone." />
+		<meta property="og:description" content="Firefox OS vous offre toutes les fonctionnalités qui vous ont donné envie d'avoir un smartphone" />
 	</head>
 	<body>
 		<?php include 'header.php';?>
@@ -31,13 +31,13 @@
 				<img src="img/zteopenc-redim.png" alt="Téléphone ZTE Open C" style="text-align:center;">
 			</div>
 			<div id="toutyest">
-				<h1>Tout y est </h1>
+				<h1>Tout y est</h1>
 				<img src="img/C-4629852-fete-redim.png" alt="firefox os cafe">
 				<p itemprop="description">Firefox OS vous offre toutes les fonctionnalités qui vous ont donné envie d'avoir un smartphone. Cela signifie que vous pouvez prendre et partager des photos, rester en contact avec vos amis et votre famille, écouter de la musique et bien d'autres choses. Il s'adapte à votre style de vie pour que vous puissiez vous adapter au monde qui vous entoure.</p>
 			</div>
 			<div id="futur">
-				<h1> Façonnez le futur</h1>
-				<p> Nous sommes ici pour changer les choses, pas pour gagner de l'argent. C'est pour cela que nos smartphones sont soutenus par une grande communauté internationnale qui innove pour vous, avec vos intérêts et besoins en tête. En choissisant Firefox OS, vous contribuez à un meilleur avenir pour le Web et les utilisateurs du monde entier.</p>
+				<h1>Façonnez le futur</h1>
+				<p>Nous sommes ici pour changer les choses, pas pour gagner de l'argent. C'est pour cela que nos smartphones sont soutenus par une grande communauté internationnale qui innove pour vous, avec vos intérêts et besoins en tête. En choissisant Firefox OS, vous contribuez à un meilleur avenir pour le Web et les utilisateurs du monde entier.</p>
 				<img itemprop="image" src="http://www.mozfr.org/custom/img/fox-front.png" alt="fox" style="max-width: 100%;">
 				<a itemprop="sameAs" href="https://www.mozilla.org/fr/firefox/os/" style="text-align:center; margin-left:20%;"><span id="ffos-learn-more" class="button" style="display: inline-block; margin-top:7%;
  margin-left:0%; text-align:center;">En savoir plus »</span></a>
@@ -45,32 +45,26 @@
 		</div> 
 		<div id="footer">
 			<div id="achat">
-				<p>Vous pouvez acheter le ZTE OPEN C chez&nbsp;: </p>
-				<ul>
-					<li itemprop="offers" itemscope itemtype="http://schema.org/Offer"><meta content="79.90" itemprop="price" /><meta content="EUR" itemprop="priceCurrency" /><span itemprop="seller">Leclerc</span>&nbsp;: <a itemprop="sameAs" href="http://www.leclercmobile.fr/telephones-mobiles/notre-gamme/mobiles/Zte_Open-C.aspx">ZTE OPEN C </a> </li>
-					<li itemprop="offers" itemscope itemtype="http://schema.org/Offer"><meta content="79.95" itemprop="price" /><meta content="EUR" itemprop="priceCurrency" /><span itemprop="seller">LDLC</span>&nbsp;: <a itemprop="sameAs" href="http://www.ldlc.com/fiche/PB00171571.html"> ZTE OPEN C</a> </li>
-					<li itemprop="offers" itemscope itemtype="http://schema.org/Offer"><meta content="79.90" itemprop="price" /><meta content="EUR" itemprop="priceCurrency" /><span itemprop="seller">Materiel.net</span>&nbsp;: <a itemprop="sameAs" href="http://www.materiel.net/smartphone/zte-open-c-bleu-107188.html"> ZTE OPEN C</a></li>
-				<li itemprop="offers" itemscope itemtype="http://schema.org/Offer"><meta content="78" itemprop="price" /><meta content="EUR" itemprop="priceCurrency" /><span itemprop="seller">Cdiscount</span>&nbsp;: <a itemprop="sameAs" href="http://www.cdiscount.com/telephonie/telephone-mobile/zte-open-c-bleu/f-144040207-zteopencbl.html"> ZTE OPEN C</a></li>
-				</ul>
-				<p>N'oubliez pas de profiter de <a href="http://www.ztefrance.com/downloads/ZTE_Open_C_-_Offre_de_Remboursement.pdf">l'offre de remboursement</a></p>
+				<p>Découvrez <a href="https://www.mozilla.org/fr/firefox/os/devices/" title="Mozilla : Firefox OS - Appareils et disponibilité — Mozilla">où acheter un smartphone avec Firefox OS</a>.</p>
+				<p>N'oubliez pas de profiter de <a href="http://blog.mozfr.org/post/2014/09/ZTE-Open-C-sous-Firefox-OS-%3A-offre-de-remboursement-prolongee" title="ZTE Open C sous Firefox OS : offre de remboursement prolongée – Communauté Mozilla francophone">l'offre de remboursement</a> de 10&nbsp;euros de <a href="http://www.ztefrance.com/firefox-open-c.php" title="ZTE France - Smartphone Open C avec Firefox OS">ZTE France</a>.</p>
 			</div>
 			<div id="reseaux">
-				<p> Retrouvez-nous sur les réseaux sociaux&nbsp;: </p>
+				<p>Retrouvez-nous sur les réseaux sociaux&nbsp;:</p>
 				<ul>
-					<li><img src="img/twitter.png" alt="twitter image"/> <a itemprop="sameAs" href="https://twitter.com/firefoxosfr">Twitter </a> et suivez <a href="https://twitter.com/search?q=%23firefoxosfr"> #FirefoxOSfr </a></li>
-					<li><img src="img/facebook.png" alt="fb image"/> <a itemprop="sameAs" href="https://www.facebook.com/firefoxosfr">Facebook </a></li>
-					<li><img src="img/googleplus1.gif" alt="g+ image"/> <a itemprop="sameAs" href="https://plus.google.com/102403271624576887074/posts"> Google+</a></li>
-					<li><img src="img/youtube.png" alt="youtube image"/> <a itemprop="sameAs" href="https://www.youtube.com/user/FirefoxOSfr"> Youtube </a></li>
-					<li><img src="img/diaspora.png" alt="diaspora image"/> <a itemprop="sameAs" href="https://free-beer.ch/u/mozfr"> Diaspora</a></li>
+					<li><img src="img/twitter.png" alt="twitter image"/> <a itemprop="sameAs" href="https://twitter.com/firefoxosfr">Twitter</a> et suivez <a href="https://twitter.com/search?q=%23firefoxosfr">#FirefoxOSfr</a></li>
+					<li><img src="img/facebook.png" alt="fb image"/> <a itemprop="sameAs" href="https://www.facebook.com/firefoxosfr">Facebook</a></li>
+					<li><img src="img/googleplus1.gif" alt="g+ image"/> <a itemprop="sameAs" href="https://plus.google.com/102403271624576887074/posts">Google+</a></li>
+					<li><img src="img/youtube.png" alt="youtube image"/> <a itemprop="sameAs" href="https://www.youtube.com/user/FirefoxOSfr">Youtube</a></li>
+					<li><img src="img/diaspora.png" alt="diaspora image"/> <a itemprop="sameAs" href="https://free-beer.ch/u/mozfr">Diaspora*</a></li>
 				</ul>
 			</div>
 			<div id="aide">
-				<p>Vous pouvez obtenir de l'aide à  différents endroits&nbsp;: </p>
+				<p>Vous pouvez obtenir de l'aide sur&nbsp;:</p>
 				<ul>	
-					<li><a href="faq.php"> Foire aux questions </a></li>
-					<li><a href="http://forums.mozfr.org">http://forums.mozfr.org</a></li>
-	    			<li><a href="https://support.mozilla.org/fr/products/firefox-os">https://support.mozilla.org/fr/products/firefox-os</a></li>
-					<li><a href="irc://irc.mozilla.org/#frenchmoz"> irc://irc.mozilla.org/#frenchmoz </a></li> 
+					<li><a href="faq.php">Notre foire aux questions</a></li>
+					<li><a href="http://forums.mozfr.org/viewforum.php?f=35">Le forum d'entraide communataire sur Firefox OS de Geckozone</a></li>
+	    			<li><a href="https://support.mozilla.org/fr/products/firefox-os">L'assistance de Firefox OS de Mozilla</a></li>
+					<li><a href="irc://irc.mozilla.org/#frenchmoz">Le canal IRC de MozFr</a></li> 
 				</ul>
 				<p>Ce site est maintenu par des bénévoles et n'est pas un site officiel de la fondation Mozilla.</p>
 			</div>


### PR DESCRIPTION
Ajout de la langue dans la balise HTML, lien vers la page de Mozilla référençant les distributeurs plutôt qu'une liste à mettre à jour, remplacement du lien de l'offre de remboursement dépassée par un lien vers notre article de blog parlant de sa prolongation et par un lien vers la page de l'Open C chez ZTE, suppression d'espaces et points inutiles, et reformulation de la liste des points d'aide.
